### PR TITLE
fix: window maximize on Windows 11

### DIFF
--- a/src/config/ipc-channels.ts
+++ b/src/config/ipc-channels.ts
@@ -7,6 +7,7 @@ const LIBRARY_UPDATED = 'library-updated';
 const SETTINGS_UPDATED = 'settings-updated';
 const APP_STATUS_MESSAGE = 'app-status-message'; // for the renderer to display status messages
 const APP_NOTIFICATION = 'app-notification'; // to display a notification using the OS notification system
+const WINDOW_MAXIMIZED_CHANGE = 'window-maximized-change';
 
 const PRELOAD_SOUNDS = 'preload-sounds';
 const PLAY_SOUND = 'play-sound';
@@ -48,6 +49,7 @@ const WINDOW_IS_MAXIMIZED = 'window-is-maximized';
 export const ipcChannels = {
 	// main -> renderer
 	APP_NOTIFICATION,
+	WINDOW_MAXIMIZED_CHANGE,
 	APP_STATUS_MESSAGE,
 	SETTINGS_UPDATED,
 	LIBRARY_UPDATED,

--- a/src/config/ipc-channels.ts
+++ b/src/config/ipc-channels.ts
@@ -39,6 +39,12 @@ const OPEN_PATH = 'open-path';
 const OPEN_URL = 'open-url';
 const OPEN_CHILD_WINDOW = 'open-child-window';
 
+// Window controls (renderer -> main)
+const WINDOW_MINIMIZE = 'window-minimize';
+const WINDOW_MAXIMIZE = 'window-maximize';
+const WINDOW_CLOSE = 'window-close';
+const WINDOW_IS_MAXIMIZED = 'window-is-maximized';
+
 export const ipcChannels = {
 	// main -> renderer
 	APP_NOTIFICATION,
@@ -75,4 +81,9 @@ export const ipcChannels = {
 	OPEN_PATH,
 	OPEN_URL,
 	OPEN_CHILD_WINDOW,
+
+	WINDOW_MINIMIZE,
+	WINDOW_MAXIMIZE,
+	WINDOW_CLOSE,
+	WINDOW_IS_MAXIMIZED,
 } as const;

--- a/src/main/create-window.ts
+++ b/src/main/create-window.ts
@@ -116,7 +116,10 @@ export const createMainWindow = async () => {
 		// titleBarOverlay: true, // https://developer.mozilla.org/en-US/docs/Web/API/Window_Controls_Overlay_API
 		trafficLightPosition: { x: 10, y: 9 },
 
-		transparent: true, // Makes the window transparent. Default is false. On Windows, does not work unless the window is frameless.
+		// transparent: true breaks window maximize/snap on Windows 11 because it
+		// removes the WS_THICKFRAME style.  Only enable on macOS where vibrancy
+		// requires it.
+		transparent: !is.windows,
 		// backgroundColor: '#00000000', // transparent hexadecimal or anything with transparency,
 		vibrancy: 'under-window', // appearance-based, titlebar, selection, menu, popover, sidebar, header, sheet, window, hud, fullscreen-ui, tooltip, content, under-window, or under-page.
 
@@ -127,11 +130,20 @@ export const createMainWindow = async () => {
 	};
 
 	if (is.windows) {
+		// On Windows, frame must be true for titleBarStyle + titleBarOverlay to
+		// work.  The base createWindow sets frame: APP_FRAME (false), so we
+		// override it here to get native window controls (minimize/maximize/close)
+		// rendered as an overlay inside the custom titlebar.
+		options.frame = true;
 		options.titleBarOverlay = {
 			color: getSetting('theme') === 'dark' ? '#000000' : '#ffffff',
 			symbolColor: String(getSetting('accentColor')) || '#000000',
 			height: 34,
 		};
+		// Provide a solid background instead of transparency so the window chrome
+		// renders correctly and maximize/snap gestures work.
+		options.backgroundColor =
+			getSetting('theme') === 'dark' ? '#000000' : '#ffffff';
 	}
 
 	const window = createWindow(options);
@@ -143,6 +155,15 @@ export const createMainWindow = async () => {
 		} else {
 			window.show();
 		}
+	});
+
+	// Notify the renderer when maximize state changes so custom titlebar
+	// controls can update their icon (maximize ↔ restore).
+	window.on('maximize', () => {
+		window.webContents.send('window-maximized-change', true);
+	});
+	window.on('unmaximize', () => {
+		window.webContents.send('window-maximized-change', false);
 	});
 
 	// Load the window

--- a/src/main/create-window.ts
+++ b/src/main/create-window.ts
@@ -9,6 +9,7 @@ import {
 import Logger from 'electron-log/main';
 import path from 'path';
 import { APP_FRAME, APP_HEIGHT, APP_WIDTH } from '../config/config';
+import { ipcChannels } from '../config/ipc-channels';
 import { setupContextMenu } from './context-menu';
 import MenuBuilder from './menu';
 import { __resources } from './paths';
@@ -130,20 +131,22 @@ export const createMainWindow = async () => {
 	};
 
 	if (is.windows) {
+		const isDarkMode = getSetting('theme') === 'dark';
+		const backgroundColor = isDarkMode ? '#000000' : '#ffffff';
+
 		// On Windows, frame must be true for titleBarStyle + titleBarOverlay to
 		// work.  The base createWindow sets frame: APP_FRAME (false), so we
 		// override it here to get native window controls (minimize/maximize/close)
 		// rendered as an overlay inside the custom titlebar.
 		options.frame = true;
 		options.titleBarOverlay = {
-			color: getSetting('theme') === 'dark' ? '#000000' : '#ffffff',
+			color: backgroundColor,
 			symbolColor: String(getSetting('accentColor')) || '#000000',
 			height: 34,
 		};
 		// Provide a solid background instead of transparency so the window chrome
 		// renders correctly and maximize/snap gestures work.
-		options.backgroundColor =
-			getSetting('theme') === 'dark' ? '#000000' : '#ffffff';
+		options.backgroundColor = backgroundColor;
 	}
 
 	const window = createWindow(options);
@@ -160,10 +163,10 @@ export const createMainWindow = async () => {
 	// Notify the renderer when maximize state changes so custom titlebar
 	// controls can update their icon (maximize ↔ restore).
 	window.on('maximize', () => {
-		window.webContents.send('window-maximized-change', true);
+		window.webContents.send(ipcChannels.WINDOW_MAXIMIZED_CHANGE, true);
 	});
 	window.on('unmaximize', () => {
-		window.webContents.send('window-maximized-change', false);
+		window.webContents.send(ipcChannels.WINDOW_MAXIMIZED_CHANGE, false);
 	});
 
 	// Load the window

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -156,6 +156,27 @@ export default {
 			clearLibrary();
 		});
 
+		// Window controls for custom titlebar (Windows)
+		ipcMain.on(ipcChannels.WINDOW_MINIMIZE, () => {
+			windows.mainWindow?.minimize();
+		});
+
+		ipcMain.on(ipcChannels.WINDOW_MAXIMIZE, () => {
+			if (windows.mainWindow?.isMaximized()) {
+				windows.mainWindow.unmaximize();
+			} else {
+				windows.mainWindow?.maximize();
+			}
+		});
+
+		ipcMain.on(ipcChannels.WINDOW_CLOSE, () => {
+			windows.mainWindow?.close();
+		});
+
+		ipcMain.handle(ipcChannels.WINDOW_IS_MAXIMIZED, () => {
+			return windows.mainWindow?.isMaximized() ?? false;
+		});
+
 		// Open a child window
 		ipcMain.on(ipcChannels.OPEN_CHILD_WINDOW, async () => {
 			if (!windows.childWindow || windows.childWindow.isDestroyed()) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -35,6 +35,11 @@ const electronHandler = {
 		ipcRenderer.send(ipcChannels.APP_NOTIFICATION, options),
 	playSound: (sound: string) => ipcRenderer.send(ipcChannels.PLAY_SOUND, sound),
 	openUrl: (url: string) => ipcRenderer.send(ipcChannels.OPEN_URL, url),
+	windowMinimize: () => ipcRenderer.send(ipcChannels.WINDOW_MINIMIZE),
+	windowMaximize: () => ipcRenderer.send(ipcChannels.WINDOW_MAXIMIZE),
+	windowClose: () => ipcRenderer.send(ipcChannels.WINDOW_CLOSE),
+	windowIsMaximized: () =>
+		ipcRenderer.invoke(ipcChannels.WINDOW_IS_MAXIMIZED),
 	ipcRenderer: {
 		invoke(channel: string, ...args: unknown[]) {
 			if (!channels.includes(channel)) {


### PR DESCRIPTION
## Problem

Window cannot be maximized on Windows 11 (#96).

### Root Causes

1. **`transparent: true` on Windows** — removes `WS_THICKFRAME`, breaking native maximize/snap gestures
2. **`frame: false` on Windows** — causes `titleBarStyle: 'hidden'` and `titleBarOverlay` to be ignored, so no native window controls render

## Fix

- Disable `transparent` on Windows (`transparent: !is.windows`)
- Set `frame: true` on Windows so `titleBarStyle: 'hidden'` + `titleBarOverlay` render native window controls
- Provide solid `backgroundColor` on Windows matching the current theme
- Add IPC channels/handlers for window-minimize, window-maximize, window-close, window-is-maximized
- Expose window control methods in the preload bridge
- Emit maximize/unmaximize state changes to renderer for UI updates

Closes #96