### PR TITLE
fix: save sidebar layout state + skip failed metadata lookups

### DIFF
--- a/src/main/media.ts
+++ b/src/main/media.ts
@@ -4,7 +4,7 @@ import ptf from 'parse-torrent-filename';
 import getUuidByString from 'uuid-by-string';
 import { PARSE_METHOD } from '../config/config';
 import queue from './q';
-import { getCachedObject, upsertMediaLibrary } from './store-actions';
+import { getCachedObject, isLookupFailed, upsertMediaLibrary } from './store-actions';
 import { fileNameRegex, isDigit } from './util';
 
 export const prettyFileName = (name: string) => {
@@ -102,9 +102,13 @@ export const addMediaToLibrary = (media: FileType) => {
 	upsertMediaLibrary(updatedMedia);
 	Logger.status(`Updated metadata for ${updatedMedia.title}`);
 
-	// If we're missing meta info, add to queue to retrieve it
+	// If we're missing meta info, add to queue to retrieve it.
+	// Skip files whose previous lookups all returned nothing (#88/#89).
 	if (!updatedMedia.tmdb || !updatedMedia.omdb || !updatedMedia.trailers) {
-		// Add to queue to retrieve meta info
-		queue.add(updatedMedia);
+		if (isLookupFailed(updatedMedia.id)) {
+			Logger.status(`Skipping re-queue for ${updatedMedia.title} (previous lookup failed)`);
+		} else {
+			queue.add(updatedMedia);
+		}
 	}
 };

--- a/src/main/q.ts
+++ b/src/main/q.ts
@@ -9,6 +9,7 @@ import { OmdbType, TmdbType, TrailersType } from '../types/meta';
 import {
 	addGenre,
 	getCachedObject,
+	markLookupFailed,
 	setCachedObject,
 	upsertMediaLibrary,
 } from './store-actions';
@@ -93,6 +94,13 @@ const finalizePendingResult = (id: string) => {
 		...(entry.trailers && { trailers: entry.trailers }),
 	};
 	pending.delete(id);
+
+	// If all three lookups returned nothing, mark this media so we
+	// don't re-queue it on every launch (fixes #88 / #89).
+	if (!entry.omdb && !entry.tmdb && !entry.trailers) {
+		markLookupFailed(id);
+	}
+
 	upsertMediaLibrary(merged);
 
 	if (qTrailer.idle() && qTMDB.idle() && qOMDB.idle()) {

--- a/src/main/store-actions.ts
+++ b/src/main/store-actions.ts
@@ -393,3 +393,25 @@ export const setCachedObject = (key: string, value: any) => {
 
 	store.set('cache', cache);
 };
+
+// Track media IDs whose metadata lookups returned no results.
+// Prevents re-queuing files (e.g. "GoPro.mp4") that will never match.
+const FAILED_LOOKUP_TIMEOUT = 7 * 24 * 60 * 60 * 1000; // retry after 1 week
+
+export const isLookupFailed = (mediaId: string): boolean => {
+	const failed: Record<string, number> = store.get('failedLookups') || {};
+	const ts = failed[mediaId];
+	if (!ts) return false;
+	if (Date.now() - ts > FAILED_LOOKUP_TIMEOUT) {
+		delete failed[mediaId];
+		store.set('failedLookups', failed);
+		return false;
+	}
+	return true;
+};
+
+export const markLookupFailed = (mediaId: string): void => {
+	const failed: Record<string, number> = store.get('failedLookups') || {};
+	failed[mediaId] = Date.now();
+	store.set('failedLookups', failed);
+};

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -42,6 +42,9 @@ export interface StoreType {
 		[key: string]: CacheType;
 	};
 
+	// Media IDs whose metadata lookups returned nothing — avoids re-queuing on every launch
+	failedLookups: Record<string, number>;
+
 	history: HistoryType[];
 
 	settings: SettingsType;
@@ -63,6 +66,10 @@ const schema: Store.Schema<StoreType> = {
 		default: {},
 	},
 	cache: {
+		type: 'object',
+		default: {},
+	},
+	failedLookups: {
 		type: 'object',
 		default: {},
 	},

--- a/src/renderer/components/layout/ResizableLayout.tsx
+++ b/src/renderer/components/layout/ResizableLayout.tsx
@@ -54,7 +54,7 @@ export function ResizableLayout({
 	const handleLayoutChange = debounce((layout: number[]) => {
 		Logger.status('Save layout', layout);
 		setSettings({
-			sidebarLayout: [40, 60],
+			sidebarLayout: layout,
 		});
 	}, DEBOUNCE_DELAY);
 


### PR DESCRIPTION
Fixes #87, #88, #89

**#87** — `ResizableLayout.handleLayoutChange` was hardcoding `[40, 60]` instead of persisting the actual layout values from the resize callback. Sidebar size now saves correctly.

**#88 / #89** — Files whose metadata lookups (TMDB, OMDB, trailers) all return nothing are tracked in a `failedLookups` store map. On subsequent launches they're skipped instead of re-queued endlessly. Entries expire after 1 week so lookups retry eventually.

Also fixes #97 indirectly: the sidebar resize bug reported on Win11 was the same underlying issue as #87 (layout never persisted). The user's workaround of resetting settings worked because it cleared the stale `[40, 60]` default.