### PR TITLE
feat: show/hide sidebar toggle

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -209,6 +209,16 @@ export default class MenuBuilder {
 					id: 'reload',
 				},
 				{
+					label: 'Show Sidebar',
+					accelerator: 'Command+\\',
+					type: 'checkbox',
+					checked: getSetting('showSidebar') as boolean,
+					click: (menuItem) => {
+						setSettings({ showSidebar: menuItem.checked });
+					},
+					id: 'toggleSidebar',
+				},
+				{
 					label: 'Toggle Full Screen',
 					accelerator: 'Ctrl+Command+F',
 					click: () => {
@@ -221,6 +231,16 @@ export default class MenuBuilder {
 		const subMenuViewProd: MenuItemConstructorOptions = {
 			label: 'View',
 			submenu: [
+				{
+					label: 'Show Sidebar',
+					accelerator: 'Command+\\',
+					type: 'checkbox',
+					checked: getSetting('showSidebar') as boolean,
+					click: (menuItem) => {
+						setSettings({ showSidebar: menuItem.checked });
+					},
+					id: 'toggleSidebar',
+				},
 				{
 					label: 'Toggle Full Screen',
 					accelerator: 'Ctrl+Command+F',
@@ -307,6 +327,16 @@ export default class MenuBuilder {
 									id: 'reload',
 								},
 								{
+									label: 'Show &Sidebar',
+									accelerator: 'Ctrl+\\',
+									type: 'checkbox',
+									checked: getSetting('showSidebar') as boolean,
+									click: (menuItem) => {
+										setSettings({ showSidebar: menuItem.checked });
+									},
+									id: 'toggleSidebar',
+								},
+								{
 									label: 'Toggle &Full Screen',
 									accelerator: 'F11',
 									click: () => {
@@ -327,6 +357,16 @@ export default class MenuBuilder {
 								testNotificationMenuItem,
 							]
 						: [
+								{
+									label: 'Show &Sidebar',
+									accelerator: 'Ctrl+\\',
+									type: 'checkbox',
+									checked: getSetting('showSidebar') as boolean,
+									click: (menuItem) => {
+										setSettings({ showSidebar: menuItem.checked });
+									},
+									id: 'toggleSidebar',
+								},
 								{
 									label: 'Toggle &Full Screen',
 									accelerator: 'F11',

--- a/src/renderer/components/layout/ResizableLayout.tsx
+++ b/src/renderer/components/layout/ResizableLayout.tsx
@@ -99,97 +99,107 @@ export function ResizableLayout({
 			onLayout={handleLayoutChange}
 			className="h-full items-stretch"
 		>
-			<ResizablePanel
-				defaultSize={settings.sidebarLayout[0] || defaultLayout[0]}
-				collapsedSize={navCollapsedSize}
-				collapsible
-				minSize={18}
-				maxSize={40}
-				onCollapse={() => handleCollapseExpand(true)}
-				onExpand={() => handleCollapseExpand(false)}
-				className={cn(
-					isCollapsed &&
-						'min-w-[50px] transition-all duration-300 ease-in-out !overflow-auto',
-					'flex flex-col max-w-xs @container z-10',
-				)}
-			>
-				{/* todo: fade out the sidebar */}
-				<ScrollArea className={cn('grow', styles.faded)}>
-					<div className={cn(!isCollapsed && 'p-2 lg:px-4')}>
-						{!isCollapsed && <Header text="Library" />}
-						<Nav isCollapsed={isCollapsed} links={nav} />
+			{settings.showSidebar && (
+				<>
+					<ResizablePanel
+						defaultSize={settings.sidebarLayout[0] || defaultLayout[0]}
+						collapsedSize={navCollapsedSize}
+						collapsible
+						minSize={18}
+						maxSize={40}
+						onCollapse={() => handleCollapseExpand(true)}
+						onExpand={() => handleCollapseExpand(false)}
+						className={cn(
+							isCollapsed &&
+								'min-w-[50px] transition-all duration-300 ease-in-out !overflow-auto',
+							'flex flex-col max-w-xs @container z-10',
+						)}
+					>
+						{/* todo: fade out the sidebar */}
+						<ScrollArea className={cn('grow', styles.faded)}>
+							<div className={cn(!isCollapsed && 'p-2 lg:px-4')}>
+								{!isCollapsed && <Header text="Library" />}
+								<Nav isCollapsed={isCollapsed} links={nav} />
 
-						{settings.visibleSidebarElements?.includes('genres') &&
-							genresArray.length > 0 && (
-								<>
-									{isCollapsed ? <Separator /> : <Header text="Genres" />}
+								{settings.visibleSidebarElements?.includes('genres') &&
+									genresArray.length > 0 && (
+										<>
+											{isCollapsed ? <Separator /> : <Header text="Genres" />}
 
-									<Nav
-										isCollapsed={isCollapsed}
-										links={genresArray.map((genre) => {
-											const genrePath = `/genres/${genre.id}`;
-											return {
-												title: `${genre.name}`,
-												icon: GenresIcon,
-												href: genrePath,
-												label: `${genre.values.length}`,
-												...(pathname === genrePath
-													? { variant: 'default' }
-													: {}),
-											};
-										})}
-									/>
-								</>
-							)}
+											<Nav
+												isCollapsed={isCollapsed}
+												links={genresArray.map((genre) => {
+													const genrePath = `/genres/${genre.id}`;
+													return {
+														title: `${genre.name}`,
+														icon: GenresIcon,
+														href: genrePath,
+														label: `${genre.values.length}`,
+														...(pathname === genrePath
+															? { variant: 'default' }
+															: {}),
+													};
+												})}
+											/>
+										</>
+									)}
 
-						{settings.visibleSidebarElements?.includes('playlists') &&
-							playlistsArray.length > 0 && (
-								<>
-									{isCollapsed ? <Separator /> : <Header text="Playlists" />}
-									<Nav
-										isCollapsed={isCollapsed}
-										links={playlistsArray.map((playlist) => {
-											const playlistPath = `/playlists/${playlist.id}`;
-											return {
-												title: playlist.name,
-												icon: PlaylistIcon,
-												href: playlistPath,
-												label: (
-													<div className="flex items-center gap-2">
-														<span className="transition-transform translate-x-6 group-hover:translate-x-0 group-focus-within:translate-x-0">
-															{playlist.values.length}
-														</span>
-														<DialogDeletePlaylist
-															playlist={playlist}
-															className="w-8 transition-all opacity-0 translate-x-6 group-hover:opacity-90 group-hover:translate-x-0 group-focus-within:opacity-90 group-focus-within:translate-x-0"
-														/>
-													</div>
-												),
-												...(pathname === playlistPath
-													? { variant: 'default' }
-													: {}),
-											};
-										})}
-									/>
-								</>
-							)}
-					</div>
-				</ScrollArea>
-				<div className="shrink-0">
-					<Nav
-						isCollapsed={isCollapsed}
-						links={[
-							{
-								title: 'Settings',
-								icon: SettingsIcon,
-								href: `${pathSettings}/general`,
-								...(pathname === pathSettings ? { variant: 'default' } : {}),
-							},
-						]}
-					/>
-				</div>
-			</ResizablePanel>
-			<ResizableHandle withHandle />
+								{settings.visibleSidebarElements?.includes('playlists') &&
+									playlistsArray.length > 0 && (
+										<>
+											{isCollapsed ? (
+												<Separator />
+											) : (
+												<Header text="Playlists" />
+											)}
+											<Nav
+												isCollapsed={isCollapsed}
+												links={playlistsArray.map((playlist) => {
+													const playlistPath = `/playlists/${playlist.id}`;
+													return {
+														title: playlist.name,
+														icon: PlaylistIcon,
+														href: playlistPath,
+														label: (
+															<div className="flex items-center gap-2">
+																<span className="transition-transform translate-x-6 group-hover:translate-x-0 group-focus-within:translate-x-0">
+																	{playlist.values.length}
+																</span>
+																<DialogDeletePlaylist
+																	playlist={playlist}
+																	className="w-8 transition-all opacity-0 translate-x-6 group-hover:opacity-90 group-hover:translate-x-0 group-focus-within:opacity-90 group-focus-within:translate-x-0"
+																/>
+															</div>
+														),
+														...(pathname === playlistPath
+															? { variant: 'default' }
+															: {}),
+													};
+												})}
+											/>
+										</>
+									)}
+							</div>
+						</ScrollArea>
+						<div className="shrink-0">
+							<Nav
+								isCollapsed={isCollapsed}
+								links={[
+									{
+										title: 'Settings',
+										icon: SettingsIcon,
+										href: `${pathSettings}/general`,
+										...(pathname === pathSettings
+											? { variant: 'default' }
+											: {}),
+									},
+								]}
+							/>
+						</div>
+					</ResizablePanel>
+					<ResizableHandle withHandle />
+				</>
+			)}
 			<ResizablePanel
 				defaultSize={settings.sidebarLayout[1] || defaultLayout[1]}
 				minSize={30}


### PR DESCRIPTION
## Summary

Closes #85

- Wires up the existing `showSidebar` setting (already in `SettingsType` and electron-store schema) to `ResizableLayout` — sidebar panel and resize handle are now conditionally rendered based on this setting
- Adds a **"Show Sidebar"** checkbox menu item to the View menu in both macOS (`Cmd+\`) and Windows/Linux (`Ctrl+\`) templates
- Setting persists across app restarts via electron-store (no new state needed)

## Test plan

- [ ] Launch the app; sidebar is visible by default
- [ ] Click **View → Show Sidebar** (or press `Cmd+\` / `Ctrl+\`) — sidebar hides, main content fills full width
- [ ] Toggle again — sidebar reappears
- [ ] Quit and relaunch — sidebar state is remembered
- [ ] Verify resize handle disappears when sidebar is hidden