### PR TITLE
feat: improve list view of media (#81)

### DIFF
--- a/src/renderer/components/media/MediaBrowser.tsx
+++ b/src/renderer/components/media/MediaBrowser.tsx
@@ -14,12 +14,12 @@ import { MediaArtwork } from '@/renderer/components/media/MediaArtwork';
 import { MediaEmptyPlaceholder } from '@/renderer/components/media/MediaEmptyPlaceholder';
 import { ButtonAddMedia } from '@/renderer/components/ui/ButtonAddMedia';
 import { SectionHeader } from '@/renderer/components/ui/SectionHeader';
-import { GridIcon, ListIcon } from '@/renderer/config/icons';
+import { GridIcon, LikedIcon, ListIcon } from '@/renderer/config/icons';
 import { useGlobalContext } from '@/renderer/context/global-context';
 import { MediaType } from '@/types/file';
 
-import { BookmarkIcon } from '@radix-ui/react-icons';
 import React, { useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { VirtuosoGrid, TableVirtuoso } from 'react-virtuoso';
 
 type Props = {
@@ -70,6 +70,7 @@ export function MediaBrowser({
 	NotFound = MediaEmptyPlaceholder,
 }: Props) {
 	const { settings, setSettings } = useGlobalContext();
+	const navigate = useNavigate();
 
 	const handleViewChange = (value: string) => {
 		setSettings({
@@ -102,6 +103,25 @@ export function MediaBrowser({
 		}),
 		[],
 	);
+
+	// Clickable row component for the list view
+	const listTableRow = useMemo(() => {
+		const Row = ({
+			item,
+			...props
+		}: {
+			item?: MediaType;
+			[key: string]: unknown;
+		}) => (
+			<TableRow
+				{...(props as React.HTMLAttributes<HTMLTableRowElement>)}
+				className="cursor-pointer"
+				onClick={() => item && navigate(`/media/${item.id}`)}
+			/>
+		);
+		Row.displayName = 'ListTableRow';
+		return Row;
+	}, [navigate]);
 
 	return (
 		<div className="h-full flex flex-col p-6">
@@ -156,23 +176,46 @@ export function MediaBrowser({
 							data={items}
 							style={{ height: '100%' }}
 							overscan={200}
+							components={{
+								TableRow: listTableRow as React.ComponentType<any>,
+							}}
 							fixedHeaderContent={() => (
 								<TableRow>
-									<TableHead className="">{$media.title}</TableHead>
+									<TableHead className="w-16"></TableHead>
+									<TableHead>{$media.title}</TableHead>
 									<TableHead>{$media.released}</TableHead>
 									<TableHead>{$media.runtime}</TableHead>
-									<TableHead className="text-right">
+									<TableHead>{$media.rating}</TableHead>
+									<TableHead className="w-16 text-right">
 										{$ui.liked.liked}
 									</TableHead>
 								</TableRow>
 							)}
 							itemContent={(_index, media) => (
 								<>
-									<TableCell className="font-medium">{media.title}</TableCell>
+									<TableCell className="w-16 p-1 pl-4">
+										{media.poster ? (
+											<img
+												src={media.poster}
+												alt={media.title}
+												width={36}
+												height={54}
+												loading="lazy"
+												decoding="async"
+												className="rounded object-cover w-9 h-[54px]"
+											/>
+										) : (
+											<div className="w-9 h-[54px] rounded bg-muted" />
+										)}
+									</TableCell>
+									<TableCell className="font-medium">
+										{media.title || media.prettyFileName}
+									</TableCell>
 									<TableCell>{media.year}</TableCell>
 									<TableCell>{media.runtime}</TableCell>
-									<TableCell>
-										<BookmarkIcon className="ml-auto" />
+									<TableCell>{media.rating}</TableCell>
+									<TableCell className="text-right">
+										{media.liked && <LikedIcon className="ml-auto" />}
 									</TableCell>
 								</>
 							)}


### PR DESCRIPTION
## Summary

Improves the list view in `MediaBrowser.tsx` to be more useful and interactive.

- **Thumbnail column**: shows a 36×54px poster (lazy-loaded) with a grey placeholder fallback when no poster is available
- **Clickable rows**: each row navigates to `/media/{id}` via a custom `TableRow` component with `useNavigate`
- **Conditional liked icon**: `LikedIcon` (filled bookmark) is now shown only when `media.liked === true`; was previously always rendering `BookmarkIcon` regardless of liked status
- **Rating column**: exposes `media.rating` (e.g. IMDB rating) as a new column
- **Title fallback**: shows `media.prettyFileName` when `media.title` is absent
- **Cleanup**: removes unused `BookmarkIcon` import; adds `LikedIcon` to the existing icons import

## Test plan

- [ ] Switch to List view — rows should show thumbnail, title, year, runtime, rating, liked columns
- [ ] Click a row → navigates to the media detail page
- [ ] Liked movies show a filled bookmark icon; non-liked movies show nothing in that column
- [ ] Movies without a poster show a grey placeholder box
- [ ] Movies without a title show `prettyFileName` in the title column

Closes #81