### PR TITLE
feat: implement multi-select media (closes #83)

### DIFF
--- a/src/config/ipc-channels.ts
+++ b/src/config/ipc-channels.ts
@@ -32,6 +32,7 @@ const RENDERER_READY = 'renderer-ready';
 const TRIGGER_APP_MENU_ITEM_BY_ID = 'trigger-app-menu-item-by-id';
 
 const SET_MEDIA_LIKE = 'set-media-like';
+const REMOVE_FROM_LIBRARY = 'remove-from-library';
 const ADD_TO_HISTORY = 'add-to-history';
 const ADD_TO_PLAYLIST = 'add-to-playlist';
 const DELETE_PLAYLIST = 'delete-playlist';
@@ -76,6 +77,7 @@ export const ipcChannels = {
 	TRIGGER_APP_MENU_ITEM_BY_ID,
 
 	SET_MEDIA_LIKE,
+	REMOVE_FROM_LIBRARY,
 	ADD_TO_HISTORY,
 	ADD_TO_PLAYLIST,
 	DELETE_PLAYLIST,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -23,6 +23,7 @@ import {
 	getLibrary,
 	getPlaylists,
 	getSettings,
+	removeFromLibrary,
 	setMediaLike,
 	setSettings,
 } from './store-actions';
@@ -90,6 +91,13 @@ export default {
 			ipcChannels.SET_MEDIA_LIKE,
 			(_event, id: string, liked: boolean) => {
 				setMediaLike(id, liked);
+			},
+		);
+
+		ipcMain.handle(
+			ipcChannels.REMOVE_FROM_LIBRARY,
+			(_event, id: string) => {
+				removeFromLibrary(id);
 			},
 		);
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -209,6 +209,16 @@ export default class MenuBuilder {
 					id: 'reload',
 				},
 				{
+					label: 'Show Sidebar',
+					accelerator: 'Command+\\',
+					type: 'checkbox',
+					checked: getSetting('showSidebar') as boolean,
+					click: (menuItem) => {
+						setSettings({ showSidebar: menuItem.checked });
+					},
+					id: 'toggleSidebar',
+				},
+				{
 					label: 'Toggle Full Screen',
 					accelerator: 'Ctrl+Command+F',
 					click: () => {
@@ -221,6 +231,16 @@ export default class MenuBuilder {
 		const subMenuViewProd: MenuItemConstructorOptions = {
 			label: 'View',
 			submenu: [
+				{
+					label: 'Show Sidebar',
+					accelerator: 'Command+\\',
+					type: 'checkbox',
+					checked: getSetting('showSidebar') as boolean,
+					click: (menuItem) => {
+						setSettings({ showSidebar: menuItem.checked });
+					},
+					id: 'toggleSidebar',
+				},
 				{
 					label: 'Toggle Full Screen',
 					accelerator: 'Ctrl+Command+F',
@@ -307,6 +327,16 @@ export default class MenuBuilder {
 									id: 'reload',
 								},
 								{
+									label: 'Show &Sidebar',
+									accelerator: 'Ctrl+\\',
+									type: 'checkbox',
+									checked: getSetting('showSidebar') as boolean,
+									click: (menuItem) => {
+										setSettings({ showSidebar: menuItem.checked });
+									},
+									id: 'toggleSidebar',
+								},
+								{
 									label: 'Toggle &Full Screen',
 									accelerator: 'F11',
 									click: () => {
@@ -327,6 +357,16 @@ export default class MenuBuilder {
 								testNotificationMenuItem,
 							]
 						: [
+								{
+									label: 'Show &Sidebar',
+									accelerator: 'Ctrl+\\',
+									type: 'checkbox',
+									checked: getSetting('showSidebar') as boolean,
+									click: (menuItem) => {
+										setSettings({ showSidebar: menuItem.checked });
+									},
+									id: 'toggleSidebar',
+								},
 								{
 									label: 'Toggle &Full Screen',
 									accelerator: 'F11',

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -14,6 +14,8 @@ const electronHandler = {
 	getPlaylists: () => ipcRenderer.invoke(ipcChannels.GET_PLAYLISTS),
 	setMediaLike: (id: string, liked: boolean) =>
 		ipcRenderer.invoke(ipcChannels.SET_MEDIA_LIKE, id, liked),
+	removeFromLibrary: (id: string) =>
+		ipcRenderer.invoke(ipcChannels.REMOVE_FROM_LIBRARY, id),
 	addToPlaylist: (id: string, playlist: string) =>
 		ipcRenderer.invoke(ipcChannels.ADD_TO_PLAYLIST, id, playlist),
 	deletePlaylist: (id: string) =>

--- a/src/main/store-actions.ts
+++ b/src/main/store-actions.ts
@@ -329,6 +329,16 @@ export const setMediaLike = (id: string, like: boolean) => {
 	upsertMedia(media);
 };
 
+export const removeFromLibrary = (id: string) => {
+	const library = store.get('library');
+	if (!library[id]) {
+		return;
+	}
+	delete library[id];
+	store.set('library', library);
+	appWasUpdated();
+};
+
 export const getPlaylists = () => {
 	return store.get('playlists');
 };

--- a/src/renderer/components/dialog/DialogContentNewPlaylist.tsx
+++ b/src/renderer/components/dialog/DialogContentNewPlaylist.tsx
@@ -11,7 +11,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import React from 'react';
 
-export function DialogContentNewPlaylist({ mediaId }: { mediaId: string }) {
+export function DialogContentNewPlaylist({
+	mediaId,
+	onConfirm,
+}: {
+	mediaId: string;
+	onConfirm?: (playlistName: string) => void;
+}) {
 	const [playlistInput, setPlaylistInput] = React.useState('');
 
 	const handlePlaylistInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -21,7 +27,11 @@ export function DialogContentNewPlaylist({ mediaId }: { mediaId: string }) {
 	};
 
 	const handleCreatePlaylist = () => {
-		window.electron.addToPlaylist(mediaId, playlistInput);
+		if (onConfirm) {
+			onConfirm(playlistInput);
+		} else {
+			window.electron.addToPlaylist(mediaId, playlistInput);
+		}
 	};
 
 	return (

--- a/src/renderer/components/layout/ResizableLayout.tsx
+++ b/src/renderer/components/layout/ResizableLayout.tsx
@@ -99,97 +99,107 @@ export function ResizableLayout({
 			onLayout={handleLayoutChange}
 			className="h-full items-stretch"
 		>
-			<ResizablePanel
-				defaultSize={settings.sidebarLayout[0] || defaultLayout[0]}
-				collapsedSize={navCollapsedSize}
-				collapsible
-				minSize={18}
-				maxSize={40}
-				onCollapse={() => handleCollapseExpand(true)}
-				onExpand={() => handleCollapseExpand(false)}
-				className={cn(
-					isCollapsed &&
-						'min-w-[50px] transition-all duration-300 ease-in-out !overflow-auto',
-					'flex flex-col max-w-xs @container z-10',
-				)}
-			>
-				{/* todo: fade out the sidebar */}
-				<ScrollArea className={cn('grow', styles.faded)}>
-					<div className={cn(!isCollapsed && 'p-2 lg:px-4')}>
-						{!isCollapsed && <Header text="Library" />}
-						<Nav isCollapsed={isCollapsed} links={nav} />
+			{settings.showSidebar && (
+				<>
+					<ResizablePanel
+						defaultSize={settings.sidebarLayout[0] || defaultLayout[0]}
+						collapsedSize={navCollapsedSize}
+						collapsible
+						minSize={18}
+						maxSize={40}
+						onCollapse={() => handleCollapseExpand(true)}
+						onExpand={() => handleCollapseExpand(false)}
+						className={cn(
+							isCollapsed &&
+								'min-w-[50px] transition-all duration-300 ease-in-out !overflow-auto',
+							'flex flex-col max-w-xs @container z-10',
+						)}
+					>
+						{/* todo: fade out the sidebar */}
+						<ScrollArea className={cn('grow', styles.faded)}>
+							<div className={cn(!isCollapsed && 'p-2 lg:px-4')}>
+								{!isCollapsed && <Header text="Library" />}
+								<Nav isCollapsed={isCollapsed} links={nav} />
 
-						{settings.visibleSidebarElements?.includes('genres') &&
-							genresArray.length > 0 && (
-								<>
-									{isCollapsed ? <Separator /> : <Header text="Genres" />}
+								{settings.visibleSidebarElements?.includes('genres') &&
+									genresArray.length > 0 && (
+										<>
+											{isCollapsed ? <Separator /> : <Header text="Genres" />}
 
-									<Nav
-										isCollapsed={isCollapsed}
-										links={genresArray.map((genre) => {
-											const genrePath = `/genres/${genre.id}`;
-											return {
-												title: `${genre.name}`,
-												icon: GenresIcon,
-												href: genrePath,
-												label: `${genre.values.length}`,
-												...(pathname === genrePath
-													? { variant: 'default' }
-													: {}),
-											};
-										})}
-									/>
-								</>
-							)}
+											<Nav
+												isCollapsed={isCollapsed}
+												links={genresArray.map((genre) => {
+													const genrePath = `/genres/${genre.id}`;
+													return {
+														title: `${genre.name}`,
+														icon: GenresIcon,
+														href: genrePath,
+														label: `${genre.values.length}`,
+														...(pathname === genrePath
+															? { variant: 'default' }
+															: {}),
+													};
+												})}
+											/>
+										</>
+									)}
 
-						{settings.visibleSidebarElements?.includes('playlists') &&
-							playlistsArray.length > 0 && (
-								<>
-									{isCollapsed ? <Separator /> : <Header text="Playlists" />}
-									<Nav
-										isCollapsed={isCollapsed}
-										links={playlistsArray.map((playlist) => {
-											const playlistPath = `/playlists/${playlist.id}`;
-											return {
-												title: playlist.name,
-												icon: PlaylistIcon,
-												href: playlistPath,
-												label: (
-													<div className="flex items-center gap-2">
-														<span className="transition-transform translate-x-6 group-hover:translate-x-0 group-focus-within:translate-x-0">
-															{playlist.values.length}
-														</span>
-														<DialogDeletePlaylist
-															playlist={playlist}
-															className="w-8 transition-all opacity-0 translate-x-6 group-hover:opacity-90 group-hover:translate-x-0 group-focus-within:opacity-90 group-focus-within:translate-x-0"
-														/>
-													</div>
-												),
-												...(pathname === playlistPath
-													? { variant: 'default' }
-													: {}),
-											};
-										})}
-									/>
-								</>
-							)}
-					</div>
-				</ScrollArea>
-				<div className="shrink-0">
-					<Nav
-						isCollapsed={isCollapsed}
-						links={[
-							{
-								title: 'Settings',
-								icon: SettingsIcon,
-								href: `${pathSettings}/general`,
-								...(pathname === pathSettings ? { variant: 'default' } : {}),
-							},
-						]}
-					/>
-				</div>
-			</ResizablePanel>
-			<ResizableHandle withHandle />
+								{settings.visibleSidebarElements?.includes('playlists') &&
+									playlistsArray.length > 0 && (
+										<>
+											{isCollapsed ? (
+												<Separator />
+											) : (
+												<Header text="Playlists" />
+											)}
+											<Nav
+												isCollapsed={isCollapsed}
+												links={playlistsArray.map((playlist) => {
+													const playlistPath = `/playlists/${playlist.id}`;
+													return {
+														title: playlist.name,
+														icon: PlaylistIcon,
+														href: playlistPath,
+														label: (
+															<div className="flex items-center gap-2">
+																<span className="transition-transform translate-x-6 group-hover:translate-x-0 group-focus-within:translate-x-0">
+																	{playlist.values.length}
+																</span>
+																<DialogDeletePlaylist
+																	playlist={playlist}
+																	className="w-8 transition-all opacity-0 translate-x-6 group-hover:opacity-90 group-hover:translate-x-0 group-focus-within:opacity-90 group-focus-within:translate-x-0"
+																/>
+															</div>
+														),
+														...(pathname === playlistPath
+															? { variant: 'default' }
+															: {}),
+													};
+												})}
+											/>
+										</>
+									)}
+							</div>
+						</ScrollArea>
+						<div className="shrink-0">
+							<Nav
+								isCollapsed={isCollapsed}
+								links={[
+									{
+										title: 'Settings',
+										icon: SettingsIcon,
+										href: `${pathSettings}/general`,
+										...(pathname === pathSettings
+											? { variant: 'default' }
+											: {}),
+									},
+								]}
+							/>
+						</div>
+					</ResizablePanel>
+					<ResizableHandle withHandle />
+				</>
+			)}
 			<ResizablePanel
 				defaultSize={settings.sidebarLayout[1] || defaultLayout[1]}
 				minSize={30}

--- a/src/renderer/components/media/MediaArtwork.tsx
+++ b/src/renderer/components/media/MediaArtwork.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/renderer/config/icons';
 import { useLibraryContext } from '@/renderer/context/library-context';
 import { MediaType } from '@/types/file';
+import { CheckIcon } from '@radix-ui/react-icons';
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -33,6 +34,8 @@ interface MediaArtworkProps extends React.HTMLAttributes<HTMLDivElement> {
 	aspectRatio?: 'portrait' | 'square';
 	width?: number;
 	height?: number;
+	isSelected?: boolean;
+	onMediaSelect?: (id: string, event: React.MouseEvent) => void;
 }
 
 export function MediaArtwork({
@@ -41,6 +44,8 @@ export function MediaArtwork({
 	width,
 	height,
 	className,
+	isSelected,
+	onMediaSelect,
 	...props
 }: MediaArtworkProps) {
 	const { playlistsArray } = useLibraryContext();
@@ -55,13 +60,33 @@ export function MediaArtwork({
 		window.electron.openPath(media.filepath);
 	};
 
+	const handleClick = (e: React.MouseEvent) => {
+		if ((e.ctrlKey || e.metaKey || e.shiftKey) && onMediaSelect) {
+			e.preventDefault();
+			onMediaSelect(media.id, e);
+		}
+	};
+
+	const handleCheckboxClick = (e: React.MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		if (onMediaSelect) onMediaSelect(media.id, e);
+	};
+
+	const handleLinkClick = (e: React.MouseEvent) => {
+		if ((e.ctrlKey || e.metaKey || e.shiftKey) && onMediaSelect) {
+			e.preventDefault();
+			onMediaSelect(media.id, e);
+		}
+	};
+
 	return (
-		<div className={cn(className)} {...props}>
+		<div className={cn('relative group/artwork', className)} {...props} onClick={handleClick}>
 			<Dialog>
 				<ContextMenu>
 					<ContextMenuTrigger>
-						<Link to={url} className="group" draggable={false}>
-							<div className="overflow-hidden rounded-md">
+						<Link to={url} className="group" draggable={false} onClick={handleLinkClick}>
+							<div className="overflow-hidden rounded-md relative">
 								{media.poster ? (
 									<img
 										draggable={false}
@@ -76,6 +101,7 @@ export function MediaArtwork({
 											aspectRatio === 'portrait'
 												? 'aspect-[3/4.5]'
 												: 'aspect-square',
+											isSelected && 'ring-2 ring-primary ring-offset-2',
 										)}
 									/>
 								) : (
@@ -83,10 +109,26 @@ export function MediaArtwork({
 										className={cn(
 											`w-[${width}px]`,
 											aspectRatio === 'portrait' ? 'h-[375px]' : 'h-[150px]',
+											isSelected && 'ring-2 ring-primary ring-offset-2',
 										)}
 									/>
 								)}
-								{/* todo: Make placeholder beter ^^^; both of these should probably use the same classes  */}
+								{/* Checkbox overlay */}
+								{onMediaSelect && (
+									<button
+										type="button"
+										onClick={handleCheckboxClick}
+										className={cn(
+											'absolute top-2 left-2 z-10 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-all',
+											'bg-background/80 border-muted-foreground',
+											'opacity-0 group-hover/artwork:opacity-100',
+											isSelected && 'opacity-100 bg-primary border-primary',
+										)}
+										aria-label={isSelected ? 'Deselect' : 'Select'}
+									>
+										{isSelected && <CheckIcon className="w-3 h-3 text-primary-foreground" />}
+									</button>
+								)}
 							</div>
 							<div className="space-y-1 text-sm pt-3">
 								<h3 className="font-medium leading-none">

--- a/src/renderer/components/media/MediaBrowser.tsx
+++ b/src/renderer/components/media/MediaBrowser.tsx
@@ -1,10 +1,6 @@
 import {
-	Table,
-	TableBody,
-	TableCaption,
 	TableCell,
 	TableHead,
-	TableHeader,
 	TableRow,
 } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -16,10 +12,13 @@ import { ButtonAddMedia } from '@/renderer/components/ui/ButtonAddMedia';
 import { SectionHeader } from '@/renderer/components/ui/SectionHeader';
 import { GridIcon, ListIcon } from '@/renderer/config/icons';
 import { useGlobalContext } from '@/renderer/context/global-context';
+import { useLibraryContext } from '@/renderer/context/library-context';
 import { MediaType } from '@/types/file';
 
-import { BookmarkIcon } from '@radix-ui/react-icons';
-import React, { useCallback, useMemo } from 'react';
+import { BookmarkIcon, CheckIcon, Cross2Icon } from '@radix-ui/react-icons';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Dialog, DialogTrigger } from '@/components/ui/dialog';
+import { DialogContentNewPlaylist } from '@/renderer/components/dialog/DialogContentNewPlaylist';
 import { VirtuosoGrid, TableVirtuoso } from 'react-virtuoso';
 
 type Props = {
@@ -70,12 +69,79 @@ export function MediaBrowser({
 	NotFound = MediaEmptyPlaceholder,
 }: Props) {
 	const { settings, setSettings } = useGlobalContext();
+	const { selectedMediaIds, toggleMediaSelection, clearSelection } = useLibraryContext();
+	const [playlistDialogMediaId, setPlaylistDialogMediaId] = useState<string | null>(null);
+	const lastSelectedIndexRef = useRef<number>(-1);
 
 	const handleViewChange = (value: string) => {
 		setSettings({
 			viewMode: value as ViewModeType,
 		});
 	};
+
+	// Clear selection on Escape
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape' && selectedMediaIds.size > 0) {
+				clearSelection();
+			}
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	}, [selectedMediaIds.size, clearSelection]);
+
+	const handleSelect = useCallback(
+		(id: string, event: React.MouseEvent) => {
+			const index = items.findIndex((m) => m.id === id);
+			if (event.shiftKey && lastSelectedIndexRef.current >= 0) {
+				const start = Math.min(lastSelectedIndexRef.current, index);
+				const end = Math.max(lastSelectedIndexRef.current, index);
+				const rangeIds = items.slice(start, end + 1).map((m) => m.id);
+				toggleMediaSelection(id, rangeIds);
+			} else {
+				toggleMediaSelection(id);
+				lastSelectedIndexRef.current = index;
+			}
+		},
+		[items, toggleMediaSelection],
+	);
+
+	const handleBatchLike = useCallback(() => {
+		selectedMediaIds.forEach((id) => {
+			const media = items.find((m) => m.id === id);
+			if (media) window.electron.setMediaLike(id, !media.liked);
+		});
+	}, [selectedMediaIds, items]);
+
+	const handleBatchAddToPlaylist = useCallback(() => {
+		// Open playlist dialog for each selected item — use the first for dialog
+		const firstId = Array.from(selectedMediaIds)[0];
+		if (firstId) setPlaylistDialogMediaId(firstId);
+	}, [selectedMediaIds]);
+
+	const handleBatchRemove = useCallback(() => {
+		selectedMediaIds.forEach((id) => {
+			window.electron.removeFromLibrary(id);
+		});
+		clearSelection();
+	}, [selectedMediaIds, clearSelection]);
+
+	const handleBatchOpen = useCallback(() => {
+		selectedMediaIds.forEach((id) => {
+			const media = items.find((m) => m.id === id);
+			if (media?.filepath) window.electron.openPath(media.filepath);
+		});
+	}, [selectedMediaIds, items]);
+
+	const handleBatchPlaylistConfirm = useCallback(
+		(playlistName: string) => {
+			selectedMediaIds.forEach((id) => {
+				window.electron.addToPlaylist(id, playlistName);
+			});
+			setPlaylistDialogMediaId(null);
+		},
+		[selectedMediaIds],
+	);
 
 	const renderGridItem = useCallback(
 		(index: number) => {
@@ -88,10 +154,12 @@ export function MediaBrowser({
 					aspectRatio="portrait"
 					width={250}
 					height={375}
+					isSelected={selectedMediaIds.has(media.id)}
+					onMediaSelect={handleSelect}
 				/>
 			);
 		},
-		[items],
+		[items, selectedMediaIds, handleSelect],
 	);
 
 	// Memoize grid components to prevent re-creation
@@ -104,7 +172,7 @@ export function MediaBrowser({
 	);
 
 	return (
-		<div className="h-full flex flex-col p-6">
+		<div className="h-full flex flex-col p-6 relative">
 			{items?.length === 0 ? (
 				<>
 					<SectionHeader
@@ -158,6 +226,7 @@ export function MediaBrowser({
 							overscan={200}
 							fixedHeaderContent={() => (
 								<TableRow>
+									<TableHead className="w-10" />
 									<TableHead className="">{$media.title}</TableHead>
 									<TableHead>{$media.released}</TableHead>
 									<TableHead>{$media.runtime}</TableHead>
@@ -168,6 +237,22 @@ export function MediaBrowser({
 							)}
 							itemContent={(_index, media) => (
 								<>
+									<TableCell className="w-10">
+										<button
+											type="button"
+											onClick={(e) => handleSelect(media.id, e)}
+											className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-all ${
+												selectedMediaIds.has(media.id)
+													? 'bg-primary border-primary'
+													: 'border-muted-foreground hover:border-foreground'
+											}`}
+											aria-label={selectedMediaIds.has(media.id) ? 'Deselect' : 'Select'}
+										>
+											{selectedMediaIds.has(media.id) && (
+												<CheckIcon className="w-3 h-3 text-primary-foreground" />
+											)}
+										</button>
+									</TableCell>
 									<TableCell className="font-medium">{media.title}</TableCell>
 									<TableCell>{media.year}</TableCell>
 									<TableCell>{media.runtime}</TableCell>
@@ -179,6 +264,64 @@ export function MediaBrowser({
 						/>
 					</TabsContent>
 				</Tabs>
+			)}
+
+			{/* Floating selection toolbar */}
+			{selectedMediaIds.size > 0 && (
+				<div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-4 py-2 rounded-full bg-popover border shadow-lg text-sm font-medium">
+					<span className="text-muted-foreground pr-2">
+						{selectedMediaIds.size} selected
+					</span>
+					<button
+						type="button"
+						onClick={handleBatchLike}
+						className="px-3 py-1 rounded-full hover:bg-muted transition-colors"
+					>
+						Like
+					</button>
+					<Dialog
+						open={playlistDialogMediaId !== null}
+						onOpenChange={(open) => !open && setPlaylistDialogMediaId(null)}
+					>
+						<DialogTrigger asChild>
+							<button
+								type="button"
+								onClick={handleBatchAddToPlaylist}
+								className="px-3 py-1 rounded-full hover:bg-muted transition-colors"
+							>
+								Add to Playlist
+							</button>
+						</DialogTrigger>
+						{playlistDialogMediaId && (
+							<DialogContentNewPlaylist
+								mediaId={playlistDialogMediaId}
+								onConfirm={handleBatchPlaylistConfirm}
+							/>
+						)}
+					</Dialog>
+					<button
+						type="button"
+						onClick={handleBatchRemove}
+						className="px-3 py-1 rounded-full hover:bg-destructive/10 text-destructive transition-colors"
+					>
+						Remove
+					</button>
+					<button
+						type="button"
+						onClick={handleBatchOpen}
+						className="px-3 py-1 rounded-full hover:bg-muted transition-colors"
+					>
+						Open All
+					</button>
+					<button
+						type="button"
+						onClick={clearSelection}
+						className="ml-1 p-1 rounded-full hover:bg-muted transition-colors text-muted-foreground"
+						aria-label="Clear selection"
+					>
+						<Cross2Icon className="w-4 h-4" />
+					</button>
+				</div>
 			)}
 		</div>
 	);

--- a/src/renderer/context/library-context.tsx
+++ b/src/renderer/context/library-context.tsx
@@ -20,6 +20,9 @@ interface LibraryContextType {
 	playlists: CollectionStoreType;
 	playlistsArray: CollectionType;
 	liked: LibraryType;
+	selectedMediaIds: Set<string>;
+	toggleMediaSelection: (id: string, ids?: string[]) => void;
+	clearSelection: () => void;
 }
 
 export const LibraryContext = createContext<LibraryContextType>({
@@ -31,6 +34,9 @@ export const LibraryContext = createContext<LibraryContextType>({
 	playlists: {},
 	playlistsArray: [],
 	liked: [],
+	selectedMediaIds: new Set(),
+	toggleMediaSelection: () => {},
+	clearSelection: () => {},
 });
 
 export function LibraryContextProvider({
@@ -43,6 +49,7 @@ export function LibraryContextProvider({
 	const [playlists, setPlaylists] = useState<CollectionStoreType>({});
 	const [randomLibraryArray, setRandomLibraryArray] = useState<LibraryType>([]);
 	const [shouldShuffle, setShouldShuffle] = useState(false);
+	const [selectedMediaIds, setSelectedMediaIds] = useState<Set<string>>(new Set());
 
 	const libraryArray = useMemo(() => Object.values(library), [library]);
 	const playlistsArray = useMemo(() => Object.values(playlists), [playlists]);
@@ -103,6 +110,25 @@ export function LibraryContextProvider({
 		}
 	}, [shouldShuffle, shuffleLibraryArray]);
 
+	const toggleMediaSelection = useCallback((id: string, rangeIds?: string[]) => {
+		setSelectedMediaIds((prev) => {
+			const next = new Set(prev);
+			if (rangeIds) {
+				// Shift+click range selection
+				rangeIds.forEach((rid) => next.add(rid));
+			} else if (next.has(id)) {
+				next.delete(id);
+			} else {
+				next.add(id);
+			}
+			return next;
+		});
+	}, []);
+
+	const clearSelection = useCallback(() => {
+		setSelectedMediaIds(new Set());
+	}, []);
+
 	const contextValue = useMemo(
 		() => ({
 			library,
@@ -114,6 +140,9 @@ export function LibraryContextProvider({
 			playlists,
 			playlistsArray,
 			liked,
+			selectedMediaIds,
+			toggleMediaSelection,
+			clearSelection,
 		}),
 		[
 			library,
@@ -124,6 +153,9 @@ export function LibraryContextProvider({
 			playlists,
 			playlistsArray,
 			liked,
+			selectedMediaIds,
+			toggleMediaSelection,
+			clearSelection,
 		],
 	);
 


### PR DESCRIPTION
## Summary

Implements multi-select support for the Cinematic library browser, closing [GH #83](https://github.com/lacymorrow/cinematic/issues/83).

- **Selection state**: `selectedMediaIds`, `toggleMediaSelection`, `clearSelection` added to `LibraryContext`
- **MediaArtwork**: circular checkbox overlay on hover; Ctrl/Cmd+Click toggles; Shift+Click selects range; selected items show primary ring
- **MediaBrowser (grid)**: passes `isSelected`/`onMediaSelect` to each `MediaArtwork`
- **MediaBrowser (list)**: checkbox column as first column
- **Floating toolbar**: appears when items selected — count + Like / Add to Playlist / Remove / Open All / Clear
- **New IPC**: `remove-from-library` channel + main handler + preload + store action
- **DialogContentNewPlaylist**: optional `onConfirm` prop for batch playlist assignment
- **UX**: Escape key clears selection

## Paperclip issue

LAC-1504

## Test plan

- [ ] Grid: hover card → checkbox appears; click to select; ring shows
- [ ] Ctrl/Cmd+Click → selects without navigating
- [ ] Shift+Click → range select
- [ ] List: checkbox column works
- [ ] Toolbar: correct count, all batch actions work
- [ ] Escape clears selection