### PR TITLE
feat: sort and liked filter for media browser (#78)

### DIFF
--- a/src/config/strings.ts
+++ b/src/config/strings.ts
@@ -111,6 +111,20 @@ export const $ui = {
 		grid: 'Grid',
 		list: 'List',
 	},
+	sort: {
+		label: 'Sort',
+		titleAsc: 'Title (A–Z)',
+		titleDesc: 'Title (Z–A)',
+		yearDesc: 'Year (Newest)',
+		yearAsc: 'Year (Oldest)',
+		runtimeDesc: 'Runtime (Longest)',
+		runtimeAsc: 'Runtime (Shortest)',
+		dateAddedDesc: 'Date Added (Newest)',
+		dateAddedAsc: 'Date Added (Oldest)',
+	},
+	filter: {
+		likedOnly: 'Liked only',
+	},
 };
 
 export const $media = {

--- a/src/renderer/components/media/MediaBrowser.tsx
+++ b/src/renderer/components/media/MediaBrowser.tsx
@@ -1,13 +1,17 @@
 import {
-	Table,
-	TableBody,
-	TableCaption,
 	TableCell,
 	TableHead,
-	TableHeader,
 	TableRow,
 } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select';
+import { Toggle } from '@/renderer/components/ui/toggle';
 import { ViewModeType } from '@/config/settings';
 import { $media, $ui } from '@/config/strings';
 import { MediaArtwork } from '@/renderer/components/media/MediaArtwork';
@@ -18,9 +22,19 @@ import { GridIcon, ListIcon } from '@/renderer/config/icons';
 import { useGlobalContext } from '@/renderer/context/global-context';
 import { MediaType } from '@/types/file';
 
-import { BookmarkIcon } from '@radix-ui/react-icons';
-import React, { useCallback, useMemo } from 'react';
+import { BookmarkFilledIcon, BookmarkIcon } from '@radix-ui/react-icons';
+import React, { useCallback, useMemo, useState } from 'react';
 import { VirtuosoGrid, TableVirtuoso } from 'react-virtuoso';
+
+type SortKey =
+	| 'title-asc'
+	| 'title-desc'
+	| 'year-desc'
+	| 'year-asc'
+	| 'runtime-desc'
+	| 'runtime-asc'
+	| 'date-added-desc'
+	| 'date-added-asc';
 
 type Props = {
 	items: MediaType[];
@@ -31,8 +45,44 @@ type Props = {
 };
 
 const CARD_WIDTH = 250;
-const CARD_HEIGHT = 430; // poster (375) + text (~55)
 const GRID_GAP = 24;
+
+const parseRuntime = (runtime: string | undefined): number => {
+	if (!runtime) return 0;
+	const match = runtime.match(/(\d+)/);
+	return match ? parseInt(match[1], 10) : 0;
+};
+
+const parseYear = (year: string | undefined): number => {
+	if (!year) return 0;
+	const match = year.match(/(\d{4})/);
+	return match ? parseInt(match[1], 10) : 0;
+};
+
+function sortItems(items: MediaType[], sortKey: SortKey): MediaType[] {
+	return [...items].sort((a, b) => {
+		switch (sortKey) {
+			case 'title-asc':
+				return (a.title ?? '').localeCompare(b.title ?? '');
+			case 'title-desc':
+				return (b.title ?? '').localeCompare(a.title ?? '');
+			case 'year-desc':
+				return parseYear(b.year) - parseYear(a.year);
+			case 'year-asc':
+				return parseYear(a.year) - parseYear(b.year);
+			case 'runtime-desc':
+				return parseRuntime(b.runtime) - parseRuntime(a.runtime);
+			case 'runtime-asc':
+				return parseRuntime(a.runtime) - parseRuntime(b.runtime);
+			case 'date-added-desc':
+				return (b.dateAdded ?? 0) - (a.dateAdded ?? 0);
+			case 'date-added-asc':
+				return (a.dateAdded ?? 0) - (b.dateAdded ?? 0);
+			default:
+				return 0;
+		}
+	});
+}
 
 // Custom grid components for VirtuosoGrid
 const GridList = React.forwardRef<
@@ -70,6 +120,8 @@ export function MediaBrowser({
 	NotFound = MediaEmptyPlaceholder,
 }: Props) {
 	const { settings, setSettings } = useGlobalContext();
+	const [sortKey, setSortKey] = useState<SortKey>('title-asc');
+	const [likedOnly, setLikedOnly] = useState(false);
 
 	const handleViewChange = (value: string) => {
 		setSettings({
@@ -77,9 +129,14 @@ export function MediaBrowser({
 		});
 	};
 
+	const processedItems = useMemo(() => {
+		const filtered = likedOnly ? items.filter((m) => m.liked) : items;
+		return sortItems(filtered, sortKey);
+	}, [items, sortKey, likedOnly]);
+
 	const renderGridItem = useCallback(
 		(index: number) => {
-			const media = items[index];
+			const media = processedItems[index];
 			if (!media) return null;
 			return (
 				<MediaArtwork
@@ -91,7 +148,7 @@ export function MediaBrowser({
 				/>
 			);
 		},
-		[items],
+		[processedItems],
 	);
 
 	// Memoize grid components to prevent re-creation
@@ -122,7 +179,7 @@ export function MediaBrowser({
 					className="space-y-6 h-full min-h-0 flex flex-col"
 					onValueChange={handleViewChange}
 				>
-					<div className="flex items-start flex-col-reverse md:flex-row md:items-start justify-between gap-4 select-none">
+					<div className="flex items-center flex-col-reverse md:flex-row justify-between gap-4 select-none flex-wrap">
 						<TabsList className="grow-0">
 							<TabsTrigger value="grid" className="relative flex gap-2">
 								<GridIcon /> {$ui.view.grid}
@@ -132,7 +189,37 @@ export function MediaBrowser({
 								{$ui.view.list}
 							</TabsTrigger>
 						</TabsList>
-						{addMediaButton && <ButtonAddMedia />}
+						<div className="flex items-center gap-2 ml-auto">
+							<Toggle
+								size="sm"
+								pressed={likedOnly}
+								onPressedChange={setLikedOnly}
+								aria-label={$ui.filter.likedOnly}
+								title={$ui.filter.likedOnly}
+							>
+								{likedOnly ? (
+									<BookmarkFilledIcon className="h-4 w-4" />
+								) : (
+									<BookmarkIcon className="h-4 w-4" />
+								)}
+							</Toggle>
+							<Select value={sortKey} onValueChange={(v) => setSortKey(v as SortKey)}>
+								<SelectTrigger className="h-9 w-44 text-sm">
+									<SelectValue placeholder={$ui.sort.label} />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="title-asc">{$ui.sort.titleAsc}</SelectItem>
+									<SelectItem value="title-desc">{$ui.sort.titleDesc}</SelectItem>
+									<SelectItem value="year-desc">{$ui.sort.yearDesc}</SelectItem>
+									<SelectItem value="year-asc">{$ui.sort.yearAsc}</SelectItem>
+									<SelectItem value="runtime-desc">{$ui.sort.runtimeDesc}</SelectItem>
+									<SelectItem value="runtime-asc">{$ui.sort.runtimeAsc}</SelectItem>
+									<SelectItem value="date-added-desc">{$ui.sort.dateAddedDesc}</SelectItem>
+									<SelectItem value="date-added-asc">{$ui.sort.dateAddedAsc}</SelectItem>
+								</SelectContent>
+							</Select>
+							{addMediaButton && <ButtonAddMedia />}
+						</div>
 					</div>
 					<SectionHeader title={title} tagline={tagline} />
 
@@ -141,7 +228,7 @@ export function MediaBrowser({
 						className="border-none p-0 outline-none flex-1 min-h-0"
 					>
 						<VirtuosoGrid
-							totalCount={items.length}
+							totalCount={processedItems.length}
 							components={gridComponents}
 							itemContent={renderGridItem}
 							overscan={600}
@@ -153,7 +240,7 @@ export function MediaBrowser({
 						className="h-full flex-col border-none p-0 data-[state=active]:flex flex-1 min-h-0"
 					>
 						<TableVirtuoso
-							data={items}
+							data={processedItems}
 							style={{ height: '100%' }}
 							overscan={200}
 							fixedHeaderContent={() => (
@@ -172,7 +259,11 @@ export function MediaBrowser({
 									<TableCell>{media.year}</TableCell>
 									<TableCell>{media.runtime}</TableCell>
 									<TableCell>
-										<BookmarkIcon className="ml-auto" />
+										{media.liked ? (
+											<BookmarkFilledIcon className="ml-auto" />
+										) : (
+											<BookmarkIcon className="ml-auto" />
+										)}
 									</TableCell>
 								</>
 							)}


### PR DESCRIPTION
Closes #78

## Summary

- Sort dropdown in the `MediaBrowser` toolbar with 8 options: Title (A–Z / Z–A), Year (Newest / Oldest), Runtime (Longest / Shortest), Date Added (Newest / Oldest)
- Liked-only toggle button (bookmark icon) that filters the current view to only liked media; icon fills when active
- Both sort and filter are applied in a single memoized pipeline — no changes to parent components or props
- List view now correctly shows filled/unfilled bookmark based on `media.liked`

## Test plan

- [ ] Open Browse — sort dropdown defaults to Title (A–Z)
- [ ] Change sort to Year (Newest) — cards re-order by year descending
- [ ] Change sort to Runtime (Longest) — items with runtime metadata sort correctly; items without runtime fall to end
- [ ] Click the bookmark toggle — only liked media shown; icon fills
- [ ] Click toggle again — all media returns
- [ ] Combine liked toggle + sort — both apply together
- [ ] Switch between Grid and List view — sort/filter state persists
- [ ] Works on Genre, Liked, and Playlist pages (all use MediaBrowser)