### PR TITLE
ci: update browserslist db before build to fix electron version lookup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install and build
         run: |
           npm install
+          npx update-browserslist-db@latest --yes
           npm run postinstall
           npm run package:mw
 
@@ -71,6 +72,7 @@ jobs:
       - name: Install and build
         run: |
           npm install
+          npx update-browserslist-db@latest --yes
           npm run postinstall
           npm run package:linux
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Install and build
         run: |
           npm install
+          npx update-browserslist-db@latest --yes
           npm run postinstall
           npm run build
 


### PR DESCRIPTION
## Problem

The CI build has been failing with:

```
BrowserslistError: Unknown version 40.9.2 of electron
```

This happens because `browserslist-config-erb` generates a query targeting `electron 40.9.2`, but the `caniuse-lite` database bundled with `browserslist` doesn't include that version yet (the database is only updated when the package is published, not when new Electron releases ship).

## Fix

Add `npx update-browserslist-db@latest --yes` before the build steps in both `build-mac-windows` and `build-linux` jobs. This refreshes the `caniuse-lite` database to include the current Electron version before webpack runs.

## Test plan
- [ ] Verify build-mac-windows job passes
- [ ] Verify build-linux job passes