### PR TITLE
ci: fix browserslist caniuse-lite update — use npm directly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install and build
         run: |
           npm install
-          npx update-browserslist-db@latest --yes
+          npm install caniuse-lite@latest
           npm run postinstall
           npm run package:mw
 
@@ -72,7 +72,7 @@ jobs:
       - name: Install and build
         run: |
           npm install
-          npx update-browserslist-db@latest --yes
+          npm install caniuse-lite@latest
           npm run postinstall
           npm run package:linux
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install and build
         run: |
           npm install
-          npx update-browserslist-db@latest --yes
+          npm install caniuse-lite@latest
           npm run postinstall
           npm run build
 


### PR DESCRIPTION
## Problem

PR #142 introduced `npx update-browserslist-db@latest --yes` to fix the `BrowserslistError: Unknown version 40.9.2 of electron` in the build. However, the fix itself failed:

```
Error: Command failed: pnpm info caniuse-lite --json
```

`update-browserslist-db` auto-detects the package manager by checking lockfiles. It found `pnpm-lock.yaml` in the repo root and tried to use pnpm — but pnpm is not installed in CI (the workflow uses `npm install`).

## Fix

Replace `npx update-browserslist-db@latest --yes` with `npm install caniuse-lite@latest` in both `build.yml` and `publish.yml`. This directly updates the `caniuse-lite` package to its latest version (which knows about electron 40.x) without any package manager detection logic.

## Test plan
- [ ] `build-mac-windows` job passes (no BrowserslistError)
- [ ] `build-linux` job passes