### PR TITLE
ci: fix browserslist — update electron-to-chromium + caniuse-lite + browserslist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install and build
         run: |
           npm install
-          npm install caniuse-lite@latest
+          npm install browserslist@latest caniuse-lite@latest electron-to-chromium@latest
           npm run postinstall
           npm run package:mw
 
@@ -72,7 +72,7 @@ jobs:
       - name: Install and build
         run: |
           npm install
-          npm install caniuse-lite@latest
+          npm install browserslist@latest caniuse-lite@latest electron-to-chromium@latest
           npm run postinstall
           npm run package:linux
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install and build
         run: |
           npm install
-          npm install caniuse-lite@latest
+          npm install browserslist@latest caniuse-lite@latest electron-to-chromium@latest
           npm run postinstall
           npm run build
 


### PR DESCRIPTION
## Problem

Previous fix (#148) installed `caniuse-lite@latest` but the BrowserslistError persisted:

```
BrowserslistError: Unknown version 40.9.2 of electron
```

Root cause: `browserslist-config-erb` generates a query targeting `electron 40.9.2`. Browserslist resolves electron versions from `electron-to-chromium` (not `caniuse-lite`). The locked `electron-to-chromium` version in `package-lock.json` predates electron 40.9.2.

## Fix

Install the latest versions of all three relevant packages:
- `electron-to-chromium@latest` — contains the electron→chromium version mapping that browserslist queries
- `caniuse-lite@latest` — browser feature database 
- `browserslist@latest` — may also pull in a compatible electron-to-chromium

## Test plan
- [ ] `build-mac-windows` job: no BrowserslistError, build completes
- [ ] `build-linux` job: no BrowserslistError, build completes