### PR TITLE
fix: add missing @radix-ui/react-toggle and react-toggle-group deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,8 @@
     "@radix-ui/react-switch": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
+    "@radix-ui/react-toggle": "^1.1.0",
+    "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@tailwindcss/container-queries": "^0.1.1",
     "@uiw/react-color-chrome": "^2.10.1",


### PR DESCRIPTION
## Problem

Build failing after feature PRs #136–#141 were merged:

```
Module not found: Error: Can't resolve '@radix-ui/react-toggle'
```

`toggle.tsx` and `toggle-group.tsx` have been in the repo since February 2025 but were previously unused. The recent feature PRs added UI components that render these primitives, exposing the fact that `@radix-ui/react-toggle` and `@radix-ui/react-toggle-group` were never listed in `package.json`.

## Fix

Add both missing packages to `dependencies` in `package.json` at version `^1.1.0` to match the existing Radix UI version pattern in the project.

## Test plan
- [ ] `build-mac-windows` passes (no module not found error)
- [ ] `build-linux` passes