### PR TITLE
ci: upgrade upload-artifact v4 → v6 (Node.js 20 deprecation fix)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           npm run package:mw
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release
           path: |
@@ -77,7 +77,7 @@ jobs:
           npm run package:linux
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release
           path: |


### PR DESCRIPTION
`actions/upload-artifact@v4` runs on Node.js 20 which GitHub is deprecating. Starting June 2nd, 2026, Node.js 20 actions will be forced to run with Node.js 24, which may break them.

Upgrades both `build-linux` and `build-mac-windows` jobs to use `actions/upload-artifact@v6` (Node.js 24 compatible, released December 2025).