### PR TITLE
fix: double-toggle in MediaArtwork multi-select (LAC-1892)

### DIFF
--- a/src/renderer/components/media/MediaArtwork.tsx
+++ b/src/renderer/components/media/MediaArtwork.tsx
@@ -73,8 +73,19 @@ export function MediaArtwork({
 		if (onMediaSelect) onMediaSelect(media.id, e);
 	};
 
+	const { onClick: onClickProp, ...divProps } = props;
+
+	const handleWrapperClick = (e: React.MouseEvent<HTMLDivElement>) => {
+		onClickProp?.(e);
+		handleClick(e);
+	};
+
 	return (
-		<div className={cn('relative group/artwork', className)} {...props} onClick={handleClick}>
+		<div
+			className={cn('relative group/artwork', className)}
+			{...divProps}
+			onClick={handleWrapperClick}
+		>
 			<Dialog>
 				<ContextMenu>
 					<ContextMenuTrigger>

--- a/src/renderer/components/media/MediaArtwork.tsx
+++ b/src/renderer/components/media/MediaArtwork.tsx
@@ -73,19 +73,12 @@ export function MediaArtwork({
 		if (onMediaSelect) onMediaSelect(media.id, e);
 	};
 
-	const handleLinkClick = (e: React.MouseEvent) => {
-		if ((e.ctrlKey || e.metaKey || e.shiftKey) && onMediaSelect) {
-			e.preventDefault();
-			onMediaSelect(media.id, e);
-		}
-	};
-
 	return (
 		<div className={cn('relative group/artwork', className)} {...props} onClick={handleClick}>
 			<Dialog>
 				<ContextMenu>
 					<ContextMenuTrigger>
-						<Link to={url} className="group" draggable={false} onClick={handleLinkClick}>
+						<Link to={url} className="group" draggable={false}>
 							<div className="overflow-hidden rounded-md relative">
 								{media.poster ? (
 									<img


### PR DESCRIPTION
## Summary
Cmd/Ctrl/Shift-click on a grid poster in Browse view toggled selection twice and netted to a no-op, breaking multi-select via modifier-click on grid cards (only the explicit checkbox overlay worked).

Root cause: `MediaArtwork` registered click handlers on **both** the wrapper `<div onClick={handleClick}>` and the inner `<Link onClick={handleLinkClick}>`. Both checked modifier keys and both invoked `onMediaSelect(media.id, e)` on the same event — the inner `handleLinkClick` only called `preventDefault()`, not `stopPropagation()`, so the event bubbled to the wrapper which toggled the selection a second time.

Fix: consolidated to a single handler on the wrapper. `handleLinkClick` and the `<Link onClick>` are removed. react-router's `Link` already skips its own navigation when a modifier key is held, so the event bubbles up; the wrapper calls `preventDefault()` (suppressing the browser's default `<a>` modifier-click behavior) and invokes `onMediaSelect` exactly once. Plain click still navigates via `Link`. The checkbox overlay button is unchanged (already has `stopPropagation`).

Paperclip: [LAC-1892](https://paperclip.ing/issues/LAC-1892)
Originally introduced in: PR #138 (multi-select)

## Acceptance criteria
- [x] Cmd/Ctrl click toggles a single item (no longer double-toggles)
- [x] Shift+click extends range from last selected
- [x] Plain click still navigates to `/media/{id}`
- [x] Checkbox overlay still works (no regression)

## Test plan
- [ ] Open Browse view with a populated library
- [ ] Cmd-click (macOS) / Ctrl-click (Win/Linux) a poster → item selected with ring + check overlay
- [ ] Shift+click another poster → range extends from last selected
- [ ] Plain click a poster → navigates to `/media/{id}`
- [ ] Hover checkbox overlay → click → toggles selection
- [ ] Escape clears selection