### PR TITLE
chore: fix package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "description": "A simple, powerful media library manager. For Mac, Windows, and Linux.",
   "license": "FSL-1.1-MIT",
   "copyright": "Copyright © Lacy Morrow",
-  "repository": "lacymorrow/cinematic",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lacymorrow/cinematic.git"
+  },
   "homepage": "https://lacymorrow.github.io/cinematic",
   "keywords": [
     "electron",


### PR DESCRIPTION
## Summary
- Normalize `repository` field in package.json per npm publish standards
- Convert string shorthand to object format with `type` and `url`

Automated fix via `npm pkg fix`.